### PR TITLE
remove unuseful type check

### DIFF
--- a/src/rqt_service_caller/service_caller_widget.py
+++ b/src/rqt_service_caller/service_caller_widget.py
@@ -146,14 +146,6 @@ class ServiceCallerWidget(QWidget):
         self._service_info['service_name'] = service_name
         self._service_info['service_class_name'] = self._services[service_name]
 
-        try:
-            package_name, service_class_name = self._services[service_name].split('/', 2)
-            if not package_name or not service_class_name:
-                raise ValueError()
-        except ValueError:
-            raise RuntimeError(
-                'The passed message type "{}" is invalid'.format(self._services[service_name]))
-
         service_class = get_service_class(self._service_info['service_class_name'])
         assert service_class, 'Could not find class {} for service: {}'.format(
             self._services[service_name], service_name)


### PR DESCRIPTION
The check I've removed in this PR is actually no longer necessary as the same check is performed in the call to `get_service_class` in line 157. In order to minimize code duplication, I've decided to remove this block. The `assert` in line 158 should yield the same error check.

I don't know if this needs a branching to dashing as with this PR no `RuntimeError` is thrown any longer.

Signed-off-by: Karsten Knese <karsten@openrobotics.org>