### PR TITLE
Add in a pytest test dependency.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,8 @@
   <exec_depend>rqt_gui_py</exec_depend>
   <exec_depend>rqt_py_common</exec_depend>
 
+  <test_depend>python3-pytest</test_depend>
+
   <export>
     <architecture_independent/>
     <rqt_gui plugin="${prefix}/plugin.xml"/>

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         'rqt_service_caller provides a GUI plugin for calling arbitrary services.'
     ),
     license='BSD',
+    tests_require=['pytest'],
     entry_points={
         'console_scripts': [
             'rqt_service_caller = ' + package_name + '.main:main',


### PR DESCRIPTION
While there are no tests currently being run, this sets it up so that it will use pytest in the future.